### PR TITLE
Fixed in correct type for modifySigOps parameter

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -317,7 +317,7 @@ void CTxMemPoolEntry::UpdateDescendantState(int64_t modifySize, CAmount modifyFe
     assert(int64_t(nCountWithDescendants) > 0);
 }
 
-void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int modifySigOps)
+void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps)
 {
     nSizeWithAncestors += modifySize;
     assert(int64_t(nSizeWithAncestors) > 0);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -110,7 +110,7 @@ public:
     // Adjusts the descendant state.
     void UpdateDescendantState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount);
     // Adjusts the ancestor state
-    void UpdateAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int modifySigOps);
+    void UpdateAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps);
     // Updates the fee delta used for mining priority score, and the
     // modified fees with descendants.
     void UpdateFeeDelta(int64_t feeDelta);


### PR DESCRIPTION
CTxMemPoolEntry::CTxMemPoolEntry's modifySigOps parameter is int while update_ancestor_state::modifySigOpsCost is int64_t. This issue was raised in #11165. It looks like the function paramaters were not changed in commit 72abd2ce3c5ad8157d3a993693df1919a6ad79c3 
 
This will avoid unexpected truncation of int64_t -> int